### PR TITLE
Improve style of _read_hosts_from_csv()

### DIFF
--- a/wolicious.pl
+++ b/wolicious.pl
@@ -80,9 +80,9 @@ sub _read_hosts_from_csv {
 
     %$hosts = ();
 
-    if (open FILE, "<", $file) {
-        my @lines = <FILE>;
-        close FILE;
+    if (open my $fh, "<", $file) {
+        my @lines = <$fh>;
+        close $fh;
 
         my @csv;
 

--- a/wolicious.pl
+++ b/wolicious.pl
@@ -80,24 +80,24 @@ sub _read_hosts_from_csv {
 
     %$hosts = ();
 
-    if (open my $fh, "<", $file) {
-        my @lines = <$fh>;
-        close $fh;
+    open my $fh, "<", $file
+        or return;
 
-        my @csv;
+    my @lines = <$fh>;
+    close $fh;
 
-        foreach my $line (@lines) {
+    my @csv;
 
-            chomp $line;
-            next unless $line;
-            next if $line =~ m/^$/;
-            next if $line =~ m/^#/;
+    foreach my $line (@lines) {
 
-            @csv = split /,/, $line;
-            my $id = shift @csv;
-            $hosts->{$id} = [@csv];
+        chomp $line;
+        next unless $line;
+        next if $line =~ m/^$/;
+        next if $line =~ m/^#/;
 
-        }
+        @csv = split /,/, $line;
+        my $id = shift @csv;
+        $hosts->{$id} = [@csv];
 
     }
 


### PR DESCRIPTION
Using filehandle glob is deprecated - it is a global variable.
Recommended practice is to use lexical filehandles.

By restructuring the code to use "open ... or return ...",
the indent level was decreased, and the code is easier to read.

_Note_: the difference is best viewed with whitespace changes ignored
(`git diff -w` / `git show -w`).
